### PR TITLE
fix: rss feed relative path to absolute for nested pages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
                         {% endfor %}
 
                         <li class="nav">
-                            <a itemprop="url" href="rss.xml">
+                            <a itemprop="url" href="/rss.xml">
                                 <span itemprop="name">Feed</span>
                             </a>
                         </li>


### PR DESCRIPTION
when anyone clicks from the secondary page of your website it finds rss.xml from that directory from not root directory i added ```/``` so the website finds the rss.xml from the root.

fixes: #1 